### PR TITLE
Migrate to Jena 3.0.1.

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -27,17 +27,17 @@
       <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-core</artifactId>
-        <version>2.13.0</version>
+        <version>3.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-arq</artifactId>
-        <version>2.13.0</version>
+        <version>3.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-tdb</artifactId>
-        <version>1.1.2</version>
+        <version>3.0.1</version>
       </dependency>
 
       <!-- Generic -->

--- a/src/store-core/pom.xml
+++ b/src/store-core/pom.xml
@@ -19,7 +19,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <oslc4j-core.version>2.2.0</oslc4j-core.version>
+    <oslc4j-core.version>2.3.0-SNAPSHOT</oslc4j-core.version>
   </properties>
 
   <dependencies>

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/ModelUnmarshallingException.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/ModelUnmarshallingException.java
@@ -16,7 +16,7 @@ package org.eclipse.lyo.store;
 
 /**
  * ModelUnmarshallingException is an exception that occurs during
- * {@link com.hp.hpl.jena.rdf.model.Model}
+ * {@link org.apache.jena.rdf.model.Model}
  * transformation.
  *
  * @author Andrew Berezovskyi (andriib@kth.se)

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/Store.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/Store.java
@@ -15,7 +15,7 @@ package org.eclipse.lyo.store;
  * #L%
  */
 
-import com.hp.hpl.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Model;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/StoreFactory.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/StoreFactory.java
@@ -15,8 +15,8 @@ package org.eclipse.lyo.store;
  * #L%
  */
 
-import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.tdb.TDBFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.tdb.TDBFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.eclipse.lyo.store.internals.SparqlStoreImpl;

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/DatasetBuilder.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/DatasetBuilder.java
@@ -14,10 +14,10 @@ package org.eclipse.lyo.store.internals;
  * #L%
  */
 
-import com.hp.hpl.jena.query.ARQ;
-import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.tdb.TDB;
-import com.hp.hpl.jena.tdb.TDBFactory;
+import org.apache.jena.query.ARQ;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.tdb.TDB;
+import org.apache.jena.tdb.TDBFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/JenaTdbStoreImpl.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/JenaTdbStoreImpl.java
@@ -15,11 +15,11 @@ package org.eclipse.lyo.store.internals;
  */
 
 import com.google.common.collect.Sets;
-import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.query.ReadWrite;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.tdb.TDB;
-import com.hp.hpl.jena.tdb.TDBFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.tdb.TDB;
+import org.apache.jena.tdb.TDBFactory;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/JenaTdbStoreImpl.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/JenaTdbStoreImpl.java
@@ -112,7 +112,7 @@ public class JenaTdbStoreImpl implements Store {
             final Collection<T> resources) throws StoreAccessException {
         try {
             final Model model = JenaModelHelper.createJenaModel(resources.toArray());
-            insertJenaModel(namedGraph, model);
+            this.putJenaModel(namedGraph, model);
             return true;
         } catch (DatatypeConfigurationException | IllegalAccessException |
                 OslcCoreApplicationException | InvocationTargetException e) {
@@ -194,6 +194,17 @@ public class JenaTdbStoreImpl implements Store {
         dataset.begin(ReadWrite.WRITE);
         try {
             dataset.addNamedModel(name.toString(), model);
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+        TDB.sync(dataset);
+    }
+
+    public void putJenaModel(final URI name, final Model model) {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            dataset.replaceNamedModel(name.toString(), model);
             dataset.commit();
         } finally {
             dataset.end();

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -15,20 +15,20 @@ package org.eclipse.lyo.store.internals;
  * #L%
  */
 
-import com.hp.hpl.jena.graph.NodeFactory;
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.query.ParameterizedSparqlString;
-import com.hp.hpl.jena.query.QueryExecution;
-import com.hp.hpl.jena.query.QuerySolutionMap;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.rdf.model.Statement;
-import com.hp.hpl.jena.rdf.model.StmtIterator;
-import com.hp.hpl.jena.rdf.model.impl.ResourceImpl;
-import com.hp.hpl.jena.sparql.modify.request.QuadDataAcc;
-import com.hp.hpl.jena.sparql.modify.request.UpdateDataInsert;
-import com.hp.hpl.jena.update.UpdateProcessor;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.ParameterizedSparqlString;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QuerySolutionMap;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.rdf.model.impl.ResourceImpl;
+import org.apache.jena.sparql.modify.request.QuadDataAcc;
+import org.apache.jena.sparql.modify.request.UpdateDataInsert;
+import org.apache.jena.update.UpdateProcessor;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/query/DatasetQueryExecutorImpl.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/query/DatasetQueryExecutorImpl.java
@@ -14,16 +14,16 @@ package org.eclipse.lyo.store.internals.query;
  * #L%
  */
 
-import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.query.QueryExecution;
-import com.hp.hpl.jena.query.QueryExecutionFactory;
-import com.hp.hpl.jena.tdb.TDBFactory;
-import com.hp.hpl.jena.update.GraphStore;
-import com.hp.hpl.jena.update.GraphStoreFactory;
-import com.hp.hpl.jena.update.UpdateExecutionFactory;
-import com.hp.hpl.jena.update.UpdateFactory;
-import com.hp.hpl.jena.update.UpdateProcessor;
-import com.hp.hpl.jena.update.UpdateRequest;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.tdb.TDBFactory;
+import org.apache.jena.update.GraphStore;
+import org.apache.jena.update.GraphStoreFactory;
+import org.apache.jena.update.UpdateExecutionFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateProcessor;
+import org.apache.jena.update.UpdateRequest;
 import org.eclipse.lyo.store.StoreFactory;
 import org.eclipse.lyo.store.internals.SparqlStoreImpl;
 import org.slf4j.Logger;

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/query/JenaQueryExecutor.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/query/JenaQueryExecutor.java
@@ -14,8 +14,8 @@ package org.eclipse.lyo.store.internals.query;
  * #L%
  */
 
-import com.hp.hpl.jena.query.QueryExecution;
-import com.hp.hpl.jena.update.UpdateProcessor;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.update.UpdateProcessor;
 
 /**
  * QueryExecutor is an interface that allows to run SPARQL queries on different triplestore

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/query/SparqlQueryExecutorBasicAuthImpl.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/query/SparqlQueryExecutorBasicAuthImpl.java
@@ -14,11 +14,11 @@ package org.eclipse.lyo.store.internals.query;
  * #L%
  */
 
-import com.hp.hpl.jena.query.QueryExecution;
-import com.hp.hpl.jena.query.QueryExecutionFactory;
-import com.hp.hpl.jena.update.UpdateExecutionFactory;
-import com.hp.hpl.jena.update.UpdateFactory;
-import com.hp.hpl.jena.update.UpdateProcessor;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.update.UpdateExecutionFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateProcessor;
 import org.apache.jena.atlas.web.auth.SimpleAuthenticator;
 
 /**

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/query/SparqlQueryExecutorImpl.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/query/SparqlQueryExecutorImpl.java
@@ -14,11 +14,11 @@ package org.eclipse.lyo.store.internals.query;
  * #L%
  */
 
-import com.hp.hpl.jena.query.QueryExecution;
-import com.hp.hpl.jena.query.QueryExecutionFactory;
-import com.hp.hpl.jena.update.UpdateExecutionFactory;
-import com.hp.hpl.jena.update.UpdateFactory;
-import com.hp.hpl.jena.update.UpdateProcessor;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.update.UpdateExecutionFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateProcessor;
 
 /**
  * SparqlQueryExecutorImpl is a SPARQL endpoint-based implementation of {@link JenaQueryExecutor}.

--- a/src/store-core/src/test/java/org/eclipse/lyo/store/DatasetBuilderTest.java
+++ b/src/store-core/src/test/java/org/eclipse/lyo/store/DatasetBuilderTest.java
@@ -14,7 +14,7 @@ package org.eclipse.lyo.store;
  * #L%
  */
 
-import com.hp.hpl.jena.query.Dataset;
+import org.apache.jena.query.Dataset;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplIT.java
+++ b/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplIT.java
@@ -14,7 +14,7 @@ package org.eclipse.lyo.store;
  * #L%
  */
 
-import com.hp.hpl.jena.query.Dataset;
+import org.apache.jena.query.Dataset;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplTest.java
+++ b/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplTest.java
@@ -14,8 +14,8 @@ package org.eclipse.lyo.store;
  * #L%
  */
 
-import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.tdb.TDBFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.tdb.TDBFactory;
 import org.eclipse.lyo.store.internals.JenaTdbStoreImpl;
 import org.junit.Before;
 

--- a/src/store-core/src/test/resources/log4j.properties
+++ b/src/store-core/src/test/resources/log4j.properties
@@ -23,4 +23,4 @@ log4j.appender.rootAppender.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
 
 
 log4j.logger.org.apache.jena=INFO
-log4j.logger.com.hp.hpl.jena=INFO
+log4j.logger.org.apache.jena=INFO


### PR DESCRIPTION
This commit fails a test, which I hope Andrii can help me decipher.
The test in question is StoreTestBase::TestStoreSuccessivePutOverwrites

Where  Assertions.assertThat(catalogs).hasSize(1) returns false, since the size is 2.

But looking at JenaTdbStoreImpl's implementation of putResources, I cannot see how the size can be but 2. You do not clear the namedGraph in this implementation (compare to SparqlStoreImpl wher you do a clear graph).

More odd that this test is fine under master, but not with Jena3.